### PR TITLE
Migrate to ruff from black, isort and flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-# CI configuration file for flake8, a tool for code quality analysis
-
-[flake8]
-
-# ignored codes:
-# E501 line length, which is already enforced by black
-ignore = E501

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,7 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
     -   id: check-added-large-files
-
--   repo: https://github.com/psf/black
-    rev: 22.6.0
-    hooks:
-    -   id: black
 
 - repo: https://github.com/commitizen-tools/commitizen
   rev: v2.37.0
@@ -20,13 +13,9 @@ repos:
   - id: commitizen-branch
     stages: [push]
 
--   repo: https://github.com/pycqa/isort
-    rev: 5.11.5
-    hooks:
-    -   id: isort
-        name: isort (python)
-
--   repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
-    hooks:
-    -   id: flake8
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.1.4
+  hooks:
+    - id: ruff
+      args: [ --fix ]
+    - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,9 @@ sort-photos = "sort_photos.main:app"
 line-length = 100
 
 [tool.ruff.lint]
-select = [
+extend-select = [
    "E",  # pycodestyle error
    "W",  # pycodestyle warning
-   "F",  # pyflakes
    "I",  # isort
    "D",  # pydocstyle
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,20 @@ dependencies = [
 [project.scripts]
 sort-photos = "sort_photos.main:app"
 
-[tool.black]
+[tool.ruff]
 line-length = 100
 
-[tool.isort]
-profile = "black"
-force_single_line = true
+[tool.ruff.lint]
+select = [
+   "E",  # pycodestyle error
+   "W",  # pycodestyle warning
+   "F",  # pyflakes
+   "I",  # isort
+   "D",  # pydocstyle
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.isort]
+force-single-line = true

--- a/sort_photos/__init__.py
+++ b/sort_photos/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line tool to rename photos by date, time and camera model, to sort them by filename."""

--- a/sort_photos/cli/__init__.py
+++ b/sort_photos/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line interface utilities for sort_photos."""

--- a/sort_photos/main.py
+++ b/sort_photos/main.py
@@ -63,14 +63,12 @@ def sort_photos(
     tag: Annotated[str, typer.Option(help="Add a tag to include in sorted files names")] = None,
 ):
     """Rename photos to easily sort them by date."""
-
     # Create output directory if necessary
     if output_dir is not None:
         output_dir.mkdir(parents=True, exist_ok=True)
 
     # Process each file in the input dir
     for input_file in [f for f in input_dir.iterdir() if not f.name.startswith(".")]:
-
         with open(input_file, "rb") as f:
             exif_tags = exifread.process_file(f, details=False)
 


### PR DESCRIPTION
Ruff replaces black, isort and flake8, allowing to centralize linters configuration, and is faster.